### PR TITLE
simulate: fix segfault when particle positions come from a star file (field of particles)

### DIFF
--- a/src/core/myapp.cpp
+++ b/src/core/myapp.cpp
@@ -657,8 +657,8 @@ wxThread::ExitCode CalculateThread::Entry( ) {
 
             if ( millis_sleeping > job_wait_time * 1000 ) {
                 // we have been waiting for 10 seconds, something probably went wrong - so die.
-                wxPrintf("Calculation thread has been waiting for something to do for %f.2 seconds - going to finish\n", job_wait_time);
-                QueueError(wxString::Format("Calculation thread has been waiting for something to do for %f.2 seconds - going to finish", job_wait_time));
+                wxPrintf("Calculation thread has been waiting for something to do for %.2f seconds - going to finish\n", job_wait_time);
+                QueueError(wxString::Format("Calculation thread has been waiting for something to do for %.2f seconds - going to finish", job_wait_time));
                 break;
             }
         }

--- a/src/core/pdb.cpp
+++ b/src/core/pdb.cpp
@@ -205,8 +205,11 @@ PDB::PDB(long   number_of_non_water_atoms,
     input_text_stream  = NULL;
     output_file_stream = NULL;
     output_text_stream = NULL;
-    // Create a total PDB object to hold all the atoms in a specimen at a given time in the trajectory
-    atoms.reserve(number_of_non_water_atoms);
+    // Create a total PDB object to hold all the atoms in a specimen at a given time in the trajectory.
+    // The container must be pre-sized (not just reserved): TransformLocalAndCombine fills it by index
+    // (atom_idx + number_of_atoms * particle_idx) when the particle positions come from a star file, and the
+    // consumers iterate over ScatteringPotential::ReturnTotalNumberOfNonSolventAtoms( ) entries.
+    atoms.resize(number_of_non_water_atoms);
 
     this->cubic_size = cubic_size;
 
@@ -702,12 +705,18 @@ void PDB::Init( ) {
         }
         wxPrintf("Max particles is %d in spot 2\n", max_number_of_noise_particles);
 
+        // Only the real atoms have been appended so far; append the noise copies so that the noise atom for
+        // (real atom i, noise particle iPart) lives at index i + number_of_real_atoms * (1 + iPart), which is
+        // how TransformLocalAndCombine addresses them.
+        MyDebugAssertTrue(atoms.size( ) == number_of_real_atoms, "Expected only the real atoms to be present before adding noise atoms");
         for ( int iPart = 0; iPart < this->max_number_of_noise_particles; iPart++ ) {
             for ( current_atom_number = 0; current_atom_number < number_of_real_atoms; current_atom_number++ ) {
-                atoms[current_atom_number + number_of_real_atoms * (1 + iPart)]                  = atoms[current_atom_number];
-                atoms[current_atom_number + number_of_real_atoms * (1 + iPart)].is_real_particle = false;
+                Atom noise_atom             = atoms[current_atom_number];
+                noise_atom.is_real_particle = false;
+                atoms.push_back(noise_atom);
             }
         }
+        MyDebugAssertTrue(atoms.size( ) == number_of_real_and_noise_atoms, "Noise atoms were not added as expected");
     }
 }
 
@@ -922,7 +931,11 @@ void PDB::TransformLocalAndCombine(PDB* pdb_ensemble, int number_of_pdbs, int fr
             // at the minimum be highly correlated based on empirical observation.
 
             if ( pdb_ensemble[current_pdb].use_star_file ) {
-                // Fetch a clean copy of the atomic coordinates for this molecule
+                // Fetch a clean copy of the atomic coordinates for this molecule. The atoms are addressed by index, so the
+                // specimen container must have been pre-sized (see the PDB(long number_of_non_water_atoms, ...) constructor).
+                MyDebugAssertTrue(this->atoms.size( ) >= pdb_ensemble[current_pdb].number_of_atoms * (current_particle + 1),
+                                  "The specimen atom container (%ld) is too small for particle %d with %ld atoms",
+                                  long(this->atoms.size( )), current_particle, pdb_ensemble[current_pdb].number_of_atoms);
                 long current_atom = 0;
                 for ( long intra_mol_current_atom = 0; intra_mol_current_atom < pdb_ensemble[current_pdb].number_of_atoms; intra_mol_current_atom++ ) {
                     current_atom              = intra_mol_current_atom + pdb_ensemble[current_pdb].number_of_atoms * current_particle;

--- a/src/gui/MatchTemplatePanel.cpp
+++ b/src/gui/MatchTemplatePanel.cpp
@@ -1427,9 +1427,11 @@ void MatchTemplatePanel::StartEstimationClick(wxCommandEvent& event) {
                     double requested_padding;
                     if ( wxString::FromUTF8(mt_padding_env).ToDouble(&requested_padding) && requested_padding >= 0.0 ) {
                         padding = float(requested_padding);
-                        WriteInfoText(wxString::Format("CISTEM_EXPERIMENTAL_MT_PADDING: padding / output box = %.0f", padding));
+                        // This block runs once per image in the packaging loop - report once per launch.
+                        if ( image_number_for_gui == 1 )
+                            WriteInfoText(wxString::Format("CISTEM_EXPERIMENTAL_MT_PADDING: padding / output box = %.0f", padding));
                     }
-                    else
+                    else if ( image_number_for_gui == 1 )
                         WriteErrorText(wxString::Format("CISTEM_EXPERIMENTAL_MT_PADDING='%s' is not a number; using %.0f", mt_padding_env, padding));
                 }
             }

--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -117,6 +117,14 @@ class SimulateApp : public MyApp {
     void        DoInteractiveUserInput( );
     std::string output_filename;
 
+    // Diagnostic and reference images are named by prefixing the output base name. The prefix goes on the file name,
+    // not on the front of the whole string, so an output base that carries a directory still lands in that directory.
+    std::string PrefixedOutputFilename(const std::string& prefix) const {
+        wxFileName prefixed(output_filename);
+        prefixed.SetName(prefix + prefixed.GetName( ));
+        return prefixed.GetFullPath( ).ToStdString( );
+    }
+
     float mean_defocus          = 0.0f;
     float defocus_1             = 0.0f;
     float defocus_2             = 0.0f;
@@ -589,6 +597,13 @@ void SimulateApp::DoInteractiveUserInput( ) {
             else {
                 SendErrorAndCrash(wxString::Format("Error: Input star file %s not found\n", preexisting_particle_file_name));
             }
+            // Each PDB in the ensemble reads the star file and is instanced at every line, and PDB::TransformLocalAndCombine
+            // addresses the star-file instances by (atom + number_of_atoms * particle) with no per-PDB offset, so with more
+            // than one PDB the particle types would be superimposed at every position and overwrite each other.
+            // Mixing particle types in one star-file-driven simulation needs the PDB to be specified per line in the star file.
+            if ( sp.pdb_file_names.size( ) > 1 ) {
+                SendErrorAndCrash(wxString::Format("an input star file is only supported with a single PDB, but %ld were given\n", (long)sp.pdb_file_names.size( )));
+            }
             // The following doesn't work if there is a .dff file
             // std::string wanted_default = std::to_string(default_number_parameters);
             // number_preexisting_particles = my_input->GetIntFromUser("Limit the number of particles used from the star file.", "0: use all", wanted_default.c_str());
@@ -609,49 +624,56 @@ void SimulateApp::DoInteractiveUserInput( ) {
 
         bool wanted_parameters_are_present = false;
         if ( use_existing_params ) {
-            // If we are using existing parameters, we enforce the following are specified.
-            if ( input_star_file.parameters_that_were_read.defocus_1 &&
-                 input_star_file.parameters_that_were_read.defocus_2 &&
-                 input_star_file.parameters_that_were_read.defocus_angle &&
-                 input_star_file.parameters_that_were_read.phase_shift &&
-                 input_star_file.parameters_that_were_read.pixel_size &&
-                 input_star_file.parameters_that_were_read.pre_exposure &&
-                 input_star_file.parameters_that_were_read.total_exposure &&
-                 input_star_file.parameters_that_were_read.microscope_spherical_aberration_mm &&
-                 input_star_file.parameters_that_were_read.microscope_voltage_kv &&
-                 input_star_file.parameters_that_were_read.beam_tilt_x &&
-                 input_star_file.parameters_that_were_read.beam_tilt_y ) {
-
-                wanted_parameters_are_present = true;
-
-                kV                   = input_star_file.ReturnMicroscopekV(0);
-                spherical_aberration = input_star_file.ReturnMicroscopeCs(0);
-
-                float max_exposure, mean_phase_shift, mean_beam_tilt_x(0.f), mean_beam_tilt_y(0.f);
-                mean_defocus     = 0.f;
-                mean_phase_shift = 0.f;
-                number_of_frames = 1;
-                // Assuming this is constant for all particles and frames FIXME
-                dose_per_frame = input_star_file.ReturnTotalExposure(0) - input_star_file.ReturnPreExposure(0);
-                // tmp override for testing FIXME
-                dose_per_frame         = 1;
-                current_total_exposure = 1;
-                pre_exposure           = 1;
-                for ( int counter = 0; counter < number_preexisting_particles; counter++ ) {
-                    mean_defocus += 0.5f * (input_star_file.ReturnDefocus1(counter) + input_star_file.ReturnDefocus2(counter));
-                    number_of_frames = std::max(number_of_frames, float(input_star_file.ReturnParticleGroup(counter))); // FIXME, why is number of frames a float, prob a bad idea
-                    mean_beam_tilt_x += input_star_file.ReturnBeamTiltX(counter);
-                    mean_beam_tilt_y += input_star_file.ReturnBeamTiltY(counter);
+            // If we are using existing parameters, the following must all be present in the star file. A star file that
+            // lacks any of them is an error: silently falling back to the interactive questions would desynchronise
+            // scripted input and simulate something other than what the star file describes.
+            wxString missing_columns;
+            auto     require_column = [&missing_columns](bool was_read, const char* column_name) {
+                if ( ! was_read ) {
+                    missing_columns += wxString::Format(" %s", column_name);
                 }
-                mean_defocus /= number_preexisting_particles;
-                beam_tilt_x      = mean_beam_tilt_x / number_preexisting_particles;
-                beam_tilt_y      = mean_beam_tilt_y / number_preexisting_particles;
-                dose_rate        = 3.0f; // FIXME this is not currently in the parameter file
-                output_star_file = input_star_file; // we may change some of the parameters or save frames
+            };
+            require_column(input_star_file.parameters_that_were_read.defocus_1, "_cisTEMDefocus1");
+            require_column(input_star_file.parameters_that_were_read.defocus_2, "_cisTEMDefocus2");
+            require_column(input_star_file.parameters_that_were_read.defocus_angle, "_cisTEMDefocusAngle");
+            require_column(input_star_file.parameters_that_were_read.phase_shift, "_cisTEMPhaseShift");
+            require_column(input_star_file.parameters_that_were_read.pixel_size, "_cisTEMPixelSize");
+            require_column(input_star_file.parameters_that_were_read.pre_exposure, "_cisTEMPreExposure");
+            require_column(input_star_file.parameters_that_were_read.total_exposure, "_cisTEMTotalExposure");
+            require_column(input_star_file.parameters_that_were_read.microscope_spherical_aberration_mm, "_cisTEMMicroscopeCsMM");
+            require_column(input_star_file.parameters_that_were_read.microscope_voltage_kv, "_cisTEMMicroscopeVoltagekV");
+            require_column(input_star_file.parameters_that_were_read.beam_tilt_x, "_cisTEMBeamTiltX");
+            require_column(input_star_file.parameters_that_were_read.beam_tilt_y, "_cisTEMBeamTiltY");
+            if ( ! missing_columns.IsEmpty( ) ) {
+                SendErrorAndCrash(wxString::Format("the input star file %s is missing required column(s):%s\n", preexisting_particle_file_name, missing_columns));
             }
-            else {
-                SendInfo("Warning: You must specify all parameters in the input star file\nIgnoring the input star file.\nQuit, or continue by entering manual parameters.\n");
+
+            wanted_parameters_are_present = true;
+
+            kV                   = input_star_file.ReturnMicroscopekV(0);
+            spherical_aberration = input_star_file.ReturnMicroscopeCs(0);
+
+            float max_exposure, mean_phase_shift, mean_beam_tilt_x(0.f), mean_beam_tilt_y(0.f);
+            mean_defocus     = 0.f;
+            mean_phase_shift = 0.f;
+            number_of_frames = 1;
+            // Assuming this is constant for all particles and frames FIXME
+            dose_per_frame = input_star_file.ReturnTotalExposure(0) - input_star_file.ReturnPreExposure(0);
+            // tmp override for testing FIXME
+            dose_per_frame         = 1;
+            current_total_exposure = 1;
+            pre_exposure           = 1;
+            for ( int counter = 0; counter < number_preexisting_particles; counter++ ) {
+                mean_defocus += 0.5f * (input_star_file.ReturnDefocus1(counter) + input_star_file.ReturnDefocus2(counter));
+                number_of_frames = std::max(number_of_frames, float(input_star_file.ReturnParticleGroup(counter))); // FIXME, why is number of frames a float, prob a bad idea
+                mean_beam_tilt_x += input_star_file.ReturnBeamTiltX(counter);
+                mean_beam_tilt_y += input_star_file.ReturnBeamTiltY(counter);
             }
+            mean_defocus /= number_preexisting_particles;
+            beam_tilt_x      = mean_beam_tilt_x / number_preexisting_particles;
+            beam_tilt_y      = mean_beam_tilt_y / number_preexisting_particles;
+            dose_rate        = 3.0f; // FIXME this is not currently in the parameter file
+            output_star_file = input_star_file; // we may change some of the parameters or save frames
         }
 
         if ( ! wanted_parameters_are_present ) {
@@ -1810,7 +1832,7 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
                 // TODO the edges should be a problem here, but maybe it is good to subtract the mean, exposure filter, then add back the mean around the edges? Can test with solvent off.
 
                 if ( SAVE_PHASE_GRATING ) {
-                    std::string fileNameOUT = "with_phaseGrating_" + std::to_string(iSlab) + this->output_filename;
+                    std::string fileNameOUT = PrefixedOutputFilename("with_phaseGrating_" + std::to_string(iSlab));
                     MRCFile     mrc_out(fileNameOUT, true);
                     scattering_potential[iSlab].WriteSlices(&mrc_out, 1, 1);
                     mrc_out.SetPixelSize(this->wanted_pixel_size);
@@ -1867,10 +1889,10 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
 
                         std::string fileNameOUT;
                         if ( iSlab < 9 ) {
-                            fileNameOUT = "withDoseFilter_phaseGrating_0" + std::to_string(iSlab) + this->output_filename;
+                            fileNameOUT = PrefixedOutputFilename("withDoseFilter_phaseGrating_0" + std::to_string(iSlab));
                         }
                         else {
-                            fileNameOUT = "withDoseFilter_phaseGrating_" + std::to_string(iSlab) + this->output_filename;
+                            fileNameOUT = PrefixedOutputFilename("withDoseFilter_phaseGrating_" + std::to_string(iSlab));
                         }
 
                         MRCFile mrc_out(fileNameOUT, true);
@@ -1927,10 +1949,10 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
 
                         std::string fileNameOUT;
                         if ( iSlab < 9 ) {
-                            fileNameOUT = "withWater_phaseGrating_0" + std::to_string(iSlab) + this->output_filename;
+                            fileNameOUT = PrefixedOutputFilename("withWater_phaseGrating_0" + std::to_string(iSlab));
                         }
                         else {
-                            fileNameOUT = "withWater_phaseGrating_" + std::to_string(iSlab) + this->output_filename;
+                            fileNameOUT = PrefixedOutputFilename("withWater_phaseGrating_" + std::to_string(iSlab));
                         }
 
                         MRCFile mrc_out(fileNameOUT, true);
@@ -1969,7 +1991,7 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
             } // end loop nSlabs
 
             if ( DO_CROSSHAIR ) {
-                std::string fileNameOUT = "crosshair" + this->output_filename;
+                std::string fileNameOUT = PrefixedOutputFilename("crosshair");
                 MRCFile     mrc_out(fileNameOUT, true);
                 coords.PadToWantedSize(&cross_hair, wanted_output_size);
                 EmpiricalDistribution<double> my_dist = cross_hair.ReturnDistributionOfRealValues( );
@@ -2150,7 +2172,7 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
 
                 timer.lap("Propagate WaveFunc");
                 if ( SAVE_PROBABILITY_WAVE && iLoop < 1 ) {
-                    std::string fileNameOUT = "withProbabilityWave_" + std::to_string(iFrame) + this->output_filename;
+                    std::string fileNameOUT = PrefixedOutputFilename("withProbabilityWave_" + std::to_string(iFrame));
                     MRCFile     mrc_out(fileNameOUT, true);
                     img_frame[0].WriteSlices(&mrc_out, 1, 1);
                     mrc_out.SetPixelSize(this->wanted_pixel_size);
@@ -2168,7 +2190,7 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
 
                 if ( DO_APPLY_DQE && is_image_loop ) {
                     if ( SAVE_WITH_DQE ) {
-                        std::string fileNameOUT = "withOUT_DQE_" + std::to_string(iFrame) + this->output_filename;
+                        std::string fileNameOUT = PrefixedOutputFilename("withOUT_DQE_" + std::to_string(iFrame));
                         MRCFile     mrc_out(fileNameOUT, true);
                         img_frame[0].WriteSlices(&mrc_out, 1, 1);
                         mrc_out.SetPixelSize(this->wanted_pixel_size);
@@ -2180,7 +2202,7 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
                     timer.lap("DQE");
 
                     if ( SAVE_WITH_DQE ) {
-                        std::string fileNameOUT = "withDQE_" + std::to_string(iFrame) + this->output_filename;
+                        std::string fileNameOUT = PrefixedOutputFilename("withDQE_" + std::to_string(iFrame));
                         MRCFile     mrc_out(fileNameOUT, true);
                         img_frame[0].WriteSlices(&mrc_out, 1, 1);
                         mrc_out.SetPixelSize(this->wanted_pixel_size);
@@ -2227,7 +2249,7 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
             }
             if ( DO_PHASE_PLATE ) {
 
-                std::string fileNameOUT = "phaseGrating_" + this->output_filename;
+                std::string fileNameOUT = PrefixedOutputFilename("phaseGrating_");
                 MRCFile     mrc_out(fileNameOUT, true);
                 coords.PadToWantedSize(&sum_phase, wanted_output_size);
                 EmpiricalDistribution<double> phase_shift_distribution = sum_phase.ReturnDistributionOfRealValues( );
@@ -2238,7 +2260,7 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
                 mrc_out.SetPixelSize(this->wanted_pixel_size);
                 mrc_out.CloseFile( );
 
-                std::string fileNameOUT2 = "detector_wavefunction2_" + this->output_filename;
+                std::string fileNameOUT2 = PrefixedOutputFilename("detector_wavefunction2_");
                 MRCFile     mrc_out2(fileNameOUT2, true);
                 coords.PadToWantedSize(&sum_detector, wanted_output_size);
                 sum_detector.WriteSlices(&mrc_out2, 1, 1);
@@ -2282,7 +2304,30 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
             parameters.total_exposure                     = current_total_exposure;
 
             if ( (ONLY_SAVE_SUMS && iFrame < 1) || (! ONLY_SAVE_SUMS) ) {
-                output_star_file.all_parameters.Add(parameters);
+                if ( use_existing_params && make_particle_stack == 0 ) {
+                    // A micrograph holding a field of particles placed from the input star file: write one line per particle.
+                    // Orientation, in-plane position and the defocus values (which set the particle's z in the specimen relative to
+                    // the mean, see PDB::Init) are the input values; the imaging parameters are those applied to the micrograph.
+                    // Lines are numbered by particle, and every particle of a frame carries that frame's exposure.
+                    for ( long iParticle = 0; iParticle < number_preexisting_particles; iParticle++ ) {
+                        cisTEMParameterLine particle_line = parameters;
+                        particle_line.position_in_stack   = iParticle + 1;
+                        particle_line.psi                 = input_star_file.ReturnPsi(iParticle);
+                        particle_line.theta               = input_star_file.ReturnTheta(iParticle);
+                        particle_line.phi                 = input_star_file.ReturnPhi(iParticle);
+                        particle_line.x_shift             = input_star_file.ReturnXShift(iParticle);
+                        particle_line.y_shift             = input_star_file.ReturnYShift(iParticle);
+                        particle_line.defocus_1           = input_star_file.ReturnDefocus1(iParticle);
+                        particle_line.defocus_2           = input_star_file.ReturnDefocus2(iParticle);
+                        particle_line.defocus_angle       = input_star_file.ReturnDefocusAngle(iParticle);
+                        particle_line.phase_shift         = input_star_file.ReturnPhaseShift(iParticle);
+                        particle_line.particle_group      = input_star_file.ReturnParticleGroup(iParticle);
+                        output_star_file.all_parameters.Add(particle_line);
+                    }
+                }
+                else {
+                    output_star_file.all_parameters.Add(parameters);
+                }
             }
 
             output_image_stack[iTilt * (int)number_of_frames + iFrame].CopyFrom(img_frame);
@@ -2394,14 +2439,13 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
     bool    over_write = true;
     MRCFile mrc_out_final(this->output_filename, over_write);
 
-    // FIXME: This will not work if there is a path in the filename.
-    std::string fileNameRefSum = "perfRef_" + this->output_filename;
+    std::string fileNameRefSum = PrefixedOutputFilename("perfRef_");
     MRCFile     mrc_ref_final;
     if ( SAVE_REF ) {
         mrc_ref_final.OpenFile(fileNameRefSum, over_write);
     }
 
-    std::string fileNameREF = "ref_" + this->output_filename;
+    std::string fileNameREF = PrefixedOutputFilename("ref_");
 
     if ( DO_PRINT ) {
         wxPrintf("\n\nnumber_of_images %d N_FRAMES %d\n\n", number_of_images, myroundint(this->number_of_frames));
@@ -2541,6 +2585,11 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
     // TODO what about different pixel sizes?
     mrc_out_final.SetPixelSize(this->wanted_pixel_size);
     mrc_out_final.CloseFile( );
+
+    if ( SAVE_REF ) {
+        mrc_ref_final.SetPixelSize(this->wanted_pixel_size);
+        mrc_ref_final.CloseFile( );
+    }
 
     //    this->parameter_file.Close();
 

--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -2403,13 +2403,6 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
 
     std::string fileNameREF = "ref_" + this->output_filename;
 
-    std::string fileNameTiltSum = "tiltSum_" + this->output_filename;
-    MRCFile     mrc_tlt_final;
-
-    if ( this->make_particle_stack <= 0 ) {
-        mrc_tlt_final.OpenFile(fileNameTiltSum, over_write);
-    }
-
     if ( DO_PRINT ) {
         wxPrintf("\n\nnumber_of_images %d N_FRAMES %d\n\n", number_of_images, myroundint(this->number_of_frames));
     }
@@ -2548,9 +2541,6 @@ void SimulateApp::probability_density_2d(PDB* pdb_ensemble, int time_step) {
     // TODO what about different pixel sizes?
     mrc_out_final.SetPixelSize(this->wanted_pixel_size);
     mrc_out_final.CloseFile( );
-
-    mrc_tlt_final.SetPixelSize(this->wanted_pixel_size);
-    mrc_tlt_final.CloseFile( );
 
     //    this->parameter_file.Close();
 
@@ -2733,8 +2723,8 @@ void SimulateApp::fill_water_potential(const PDB* current_specimen, Image* scatt
     long n_waters_ignored = 0;
 #pragma omp parallel for num_threads(this->number_of_threads)                                                                                                        \
         schedule(static, water_box->number_of_waters / number_of_threads) private(radius, ix, iy, iz, dx, dy, dz, x1, y1, z1, indX, indY, indZ, int_x, int_y, int_z, \
-                                                                                  sx, sy, iSubPixX, iSubPixY, iSubPixZ, iSubPixLinearIndex,                          \
-                                                                                  n_waters_ignored, current_weight, current_distance, current_potential)
+                                                                                          sx, sy, iSubPixX, iSubPixY, iSubPixZ, iSubPixLinearIndex,                  \
+                                                                                          n_waters_ignored, current_weight, current_distance, current_potential)
 
     for ( int current_atom = 0; current_atom < water_box->number_of_waters; current_atom++ ) {
 


### PR DESCRIPTION
## Problem

`simulate` segfaulted whenever the particle positions/orientations came from an input star file — in particular the "micrograph with a field of particles" mode (*Use an existing set of orientations* = yes, *particle stack* = 0). One particle or many, stack or micrograph, all crashed in `PDB::TransformLocalAndCombine` (`pdb.cpp:929`, `Atom::operator=` on a `wxString` at `0xffff…`).

## Cause

The `std::vector` port (010648ef) translated the wxObjArray `my_atoms.Alloc(n); my_atoms.Add(dummy_atom, n)` in `PDB::PDB(long number_of_non_water_atoms, …)` to `atoms.reserve(n)`. `reserve()` leaves `size() == 0`, but the star-file branch of `TransformLocalAndCombine` fills the specimen container by index (`atom_idx + number_of_atoms * particle_idx`), and the consumers (`ScatteringPotential::calc_scattering_potential` via `atoms.at()`, `TransformGlobalAndSortOnZ`) iterate over `ReturnTotalNumberOfNonSolventAtoms()` entries. The non-star branch had been ported to `clear()`/`push_back()` and so kept working.

The same port left `PDB::Init` appending only the real atoms while the noise-particle copies (`max_number_of_noise_particles > 0`) were assigned by index past `size()` — undefined behaviour that happened not to fault (writes landed in reserved capacity).

## Commits

1. **`pdb.cpp`** — `atoms.resize(n)` in that constructor (restores the pre-port contract); noise copies appended with `push_back`; debug asserts on the container size in both places.
2. **`simulate.cpp`** — remove the dead `tiltSum_<output>` `MRCFile`: PR #292 removed its only write but left open/`SetPixelSize`/close, so micrograph runs produced an empty file and **debug builds aborted at the end of every run** on `MRCHeader::SetPixelSize`'s "Dimensions not set yet!" assert (after the real outputs had been written). Also carries a two-line clang-format-18 whitespace re-alignment of the `fill_water_potential` OpenMP pragma (pre-existing; the pre-commit hook checks the whole file).
3. **`simulate.cpp`** follow-ups for star-driven micrographs:
   - a star file missing a required column (`Defocus1/2/Angle, PhaseShift, PixelSize, PreExposure, TotalExposure, MicroscopeCsMM, MicroscopeVoltagekV, BeamTiltX/Y`) is an **error naming the missing columns**, not a warning that fell through to the interactive questions;
   - **more than one PDB with a star file is refused** — every PDB is instanced at every star line and the star-file branch indexes with no per-PDB offset, so the types would be superimposed and overwrite each other (mixing types needs the PDB named per star line: separate feature);
   - the **output star has one line per placed particle** (input psi/theta/phi, x/y shift, defocus, particle group; the micrograph's imaging parameters), numbered by particle — previously one zeroed line;
   - prefixed diagnostic/reference outputs (`perfRef_`, `phaseGrating_`, `withDQE_`, …) put the prefix on the **basename** (`PrefixedOutputFilename()`), so an output base with a directory works instead of aborting on `perfRef_/path/…`;
   - `perfRef_` gets `SetPixelSize()` + explicit close (its header pixel size was 1/256 Å).

Each commit was compiled on its own (debug clang build, `build_env:v1.1.6`, `--enable-experimental --enable-debugmode`).

## Repro / validation

Debug build in the dev image, `7kfz.cif` (KRAS, 6559 atoms) from `/plasmonlabs/reference_images/TM_tests/SPA/Kras/Templates/`, 256 px @ 1.0 Å, 1 e/Å², 1 frame, star file with 4 lines at XShift/YShift = (±60, ±60) Å. stdin answers:

```
<out> / no / 256 / 4 / 7kfz.cif / no / 1.0 / 0 / 15 / yes / field4.star / 0 / no / no
```

| case | before | after |
|---|---|---|
| field of 4 via star (micrograph) | SIGSEGV `pdb.cpp:929` | exit 0; `perfRef_` windowed std 0.044–0.052 at all 4 star positions vs 0.012–0.021 at centre/between; output star has the 4 particles |
| same with an absolute output base | abort in `MRCFile::OpenFile("perfRef_/…")` | exit 0, all outputs in the target directory, `perfRef_` pixel size 1.0 Å |
| 1 particle via star | SIGSEGV `pdb.cpp:929` | exit 0; signal only at centre |
| no star, 1 particle (positive control) | ran, then debug abort in `SetPixelSize` | exit 0; signal only at centre |
| 2-particle stack + 2 noise particles | ran (UB), then debug abort | exit 0 |
| star without `PreExposure/TotalExposure` | warning, fell through to manual questions | `Error : the input star file … is missing required column(s): _cisTEMPreExposure _cisTEMTotalExposure`, exit |
| 2 PDB types + star | would run with superimposed/overwritten atoms | `Error : an input star file is only supported with a single PDB, but 2 were given`, exit |
| checker negative controls (single ref vs field positions; field ref with centre as "expected") | — | FAIL as expected |

Scripts, star files and outputs: `/tmp/simulate_fix_build/repro` on salina (`run_simulate.sh`, `run_simulate_nostar.sh`, `run_simulate_2pdb.sh`, `check_field.py`).

## Not addressed

- Per-line PDB selection from the star file to allow mixed particle types in one field (agreed 2026-08-25, later PR): take the PDB from `_cisTEMReference3DFilename`; up-front validation is only (a) the column is present (`parameters_that_were_read.reference_3d_filename`) and (b) every distinct file named exists (`DoesFileExist`), checked alongside the required-column check before any PDB is read. The single-PDB guard in this PR is then replaced by that lane.
- `SendErrorAndCrash` in debug builds aborts without flushing stdout, so under a pipe the error text is lost unless the binary runs with `stdbuf -o0` (core behaviour, not simulate-specific).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWJQhRmZrB1HVwDmYDdz3L
